### PR TITLE
Patch FindLibunwind probe to compile under GCC 14

### DIFF
--- a/recipe/find_libunwind_pointer_type.patch
+++ b/recipe/find_libunwind_pointer_type.patch
@@ -1,0 +1,19 @@
+Backport of upstream KDE/heaptrack commit c6c45f3455a652c38aefa402aece5dafa492e8ab
+to make the unw_backtrace/unw_backtrace_skip probes compile under GCC 14, which
+treats -Wincompatible-pointer-types as an error by default. Passing `&buf` (type
+`void* (*)[10]`) to `unw_backtrace(void**, int)` is rejected; dropping the `&`
+lets the array decay to `void**`.
+
+--- cmake/FindLibunwind.cmake.orig
++++ cmake/FindLibunwind.cmake
+@@ -57,8 +57,8 @@ if (LIBUNWIND_LIBRARY)
+                           LIBUNWIND_HAS_UNW_GETCONTEXT)
+   check_c_source_compiles("#define UNW_LOCAL_ONLY 1\n#include <libunwind.h>\nint main() { unw_context_t context; unw_cursor_t cursor; unw_getcontext(&context); unw_init_local(&cursor, &context); return 0; }"
+                           LIBUNWIND_HAS_UNW_INIT_LOCAL)
+-  check_c_source_compiles("#define UNW_LOCAL_ONLY 1\n#include <libunwind.h>\nint main() { void* buf[10]; unw_backtrace(&buf, 10); return 0; }" LIBUNWIND_HAS_UNW_BACKTRACE)
+-  check_c_source_compiles ("#define UNW_LOCAL_ONLY 1\n#include <libunwind.h>\nint main() { void* buf[10]; unw_backtrace_skip(&buf, 10, 2); return 0; }" LIBUNWIND_HAS_UNW_BACKTRACE_SKIP)
++  check_c_source_compiles("#define UNW_LOCAL_ONLY 1\n#include <libunwind.h>\nint main() { void* buf[10]; unw_backtrace(buf, 10); return 0; }" LIBUNWIND_HAS_UNW_BACKTRACE)
++  check_c_source_compiles ("#define UNW_LOCAL_ONLY 1\n#include <libunwind.h>\nint main() { void* buf[10]; unw_backtrace_skip(buf, 10, 2); return 0; }" LIBUNWIND_HAS_UNW_BACKTRACE_SKIP)
+   check_c_source_compiles ("#define UNW_LOCAL_ONLY 1\n#include <libunwind.h>\nint main() { return unw_set_cache_size(unw_local_addr_space, 1024, 0); }" LIBUNWIND_HAS_UNW_SET_CACHE_SIZE)
+   check_c_source_compiles ("#define UNW_LOCAL_ONLY 1\n#include <libunwind.h>\nint main() { return unw_set_caching_policy(unw_local_addr_space, UNW_CACHE_PER_THREAD); }" LIBUNWIND_HAS_UNW_CACHE_PER_THREAD)
+   set(CMAKE_REQUIRED_QUIET ${CMAKE_REQUIRED_QUIET_SAVE})

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
   patches:
     - stdc_format.patch
     - find_libunwind_pointer_type.patch
+    - robin_map_cmake_min_version.patch
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,10 @@ source:
   folder: source
   patches:
     - stdc_format.patch
+    - find_libunwind_pointer_type.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [not linux]
   ignore_run_exports:
     - elfutils

--- a/recipe/robin_map_cmake_min_version.patch
+++ b/recipe/robin_map_cmake_min_version.patch
@@ -1,0 +1,14 @@
+The bundled 3rdparty/robin-map declares cmake_minimum_required(VERSION 3.1).
+CMake 4 removes compatibility with versions < 3.5 and refuses to configure.
+Bump the minimum to 3.5, matching the spirit of upstream KDE/heaptrack
+commit c8772730a3e188a0ac30d820ee51a0419c7618ed (which carried this fix
+inside a larger robin-map v1.3.0 import).
+
+--- 3rdparty/robin-map/CMakeLists.txt.orig
++++ 3rdparty/robin-map/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.1)
++cmake_minimum_required(VERSION 3.5)
+
+ project(tsl-robin-map VERSION 1.2.1 LANGUAGES CXX)
+


### PR DESCRIPTION
## Summary

- The `unw_backtrace` / `unw_backtrace_skip` probes in heaptrack v1.5.0's `cmake/FindLibunwind.cmake` pass `&buf` (`void* (*)[10]`) where `void**` is expected. GCC 14 makes `-Wincompatible-pointer-types` an error by default, so the probe fails to compile and `find_package(Libunwind REQUIRED)` bails out.
- This has been blocking every rebuild PR since libunwind 1.8 (PRs #18, #19, #20, #21, #22): see the [PR #22 linux_64 job](https://github.com/conda-forge/heaptrack-feedstock/actions/runs/24961994997/job/73090137118?pr=22) — \`Could NOT find Libunwind (missing: LIBUNWIND_HAS_UNW_BACKTRACE) (found version "1.8.3")\`.
- Backports upstream fix [KDE/heaptrack@c6c45f3](https://github.com/KDE/heaptrack/commit/c6c45f3455a652c38aefa402aece5dafa492e8ab) (which has not been included in a tagged release yet — v1.5.0 is still latest). Drops the `&` so the array decays to a pointer.

After this merges, the autotick PRs #18–#22 can be re-run (e.g. via \`@conda-forge-admin, please rerun bot\`) and should get past CMake configuration.

## Test plan

- [x] CI on this PR (linux_64_, linux_aarch64_, linux_ppc64le_) reaches the compile phase past `find_package(Libunwind REQUIRED)` and builds heaptrack 1.5.0 build 2.
- [ ] Recipe smoke test `heaptrack_print --help` passes.